### PR TITLE
use b-splines to calculate moments; add spline keyword

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Orso Meneghini <orso82@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/src/MillerExtendedHarmonic.jl
+++ b/src/MillerExtendedHarmonic.jl
@@ -3,6 +3,7 @@ module MillerExtendedHarmonic
 using RecipesBase
 import LinearAlgebra: dot
 using Optim
+using Dierckx
 
 const halfpi = 0.5 * π
 


### PR DESCRIPTION
This is more accurate for higher mode numbers. default is to use trapz since splines are 5-10x slower.

```julia
import MillerExtendedHarmonic
using MXHEquilibrium
using PyPlot
using EFIT
g = readg("/home/lstagner/.julia/dev/MXHEquilibrium/test/g150219.03200")

M = efit(g,clockwise_phi=false)
bdry = plasma_boundary(M)

fig,ax = plt.subplots(ncols=5)
fig.set_size_inches(12,5)
for (i,N) in enumerate(2:2:10)
    @time mxh1 = MillerExtendedHarmonic.MXH(bdry.r,bdry.z,N; spline=false);
    @time mxh2 = MillerExtendedHarmonic.MXH(bdry.r,bdry.z,N; spline=true);
    ax[i].plot(bdry.r,bdry.z,color="black")

    x1,y1 = mxh1(100)
    ax[i].plot(x1,y1,color="b",ls="--",label="trapz")
    x2,y2 = mxh2(100)
    ax[i].plot(x2,y2,color="r",ls="--",label="spline")
    ax[i].legend(title="N=$N")
    ax[i].set_aspect("equal")
end
fig.tight_layout()
```
![image](https://github.com/ProjectTorreyPines/MillerExtendedHarmonic.jl/assets/4305891/88eb6bd3-7f02-4518-84e6-f12ac551b36d)
