### PR TITLE
(compat): support Optim v2 in `optimize_fit` + add test suite

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.11"
+          - "1.x"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        arch:
+          - x64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+
+      - uses: julia-actions/cache@v2
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1
+
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,24 @@
 name = "MillerExtendedHarmonic"
 uuid = "c82744c2-dc08-461a-8c37-87ab04d0f9b8"
-authors = ["Orso Meneghini <orso82@gmail.com>"]
 version = "2.1.1"
+authors = ["Orso Meneghini <orso82@gmail.com>"]
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 Dierckx = "0.5.4"
-Optim = "1"
+ForwardDiff = "0.10, 1"
+Optim = "1, 2"
 RecipesBase = "1"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/MXH.jl
+++ b/src/MXH.jl
@@ -759,6 +759,9 @@ function fit_residual(x, pr, pz)
     return res
 end
 
+# Optim v2 takes an ADTypes backend for `autodiff`; v1 takes the legacy Symbol
+const AUTODIFF_FORWARD = pkgversion(Optim) >= v"2" ? Optim.ADTypes.AutoForwardDiff() : :forward
+
 function optimize_fit!(flat::AbstractVector{<:Real}, pr::AbstractVector{<:Real}, pz::AbstractVector{<:Real}; inner_optimizer=Optim.LBFGS(), debug=false)
 
     f = x -> fit_residual(x, pr, pz)
@@ -801,7 +804,7 @@ function optimize_fit!(flat::AbstractVector{<:Real}, pr::AbstractVector{<:Real},
 
     algo = Optim.Fminbox(inner_optimizer)
     options = Optim.Options()#store_trace=true, show_trace=true)
-    res = Optim.optimize(f, lower, upper, flat, algo, options; autodiff=:forward)
+    res = Optim.optimize(f, lower, upper, flat, algo, options; autodiff=AUTODIFF_FORWARD)
     #debug && println("Residual: ", f(res.minimizer))
 
     Rmin = res.minimizer[1]

--- a/src/MillerExtendedHarmonic.jl
+++ b/src/MillerExtendedHarmonic.jl
@@ -3,6 +3,7 @@ module MillerExtendedHarmonic
 using RecipesBase
 import LinearAlgebra: dot
 using Optim
+import ForwardDiff  # backend for Optim's forward-mode autodiff (required explicitly by Optim v2)
 using Dierckx
 
 const halfpi = 0.5 * π

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,122 @@
+using MillerExtendedHarmonic
+using Test
+
+const MXHmod = MillerExtendedHarmonic
+
+@testset "MillerExtendedHarmonic.jl" begin
+    @testset "construction and derived properties" begin
+        mxh = MXH(3.0, 0.5, 0.3, 1.8, 0.0, [0.0, 0.0], [asin(0.4), -0.1])
+        @test mxh.R0 == 3.0
+        @test mxh.Z0 == 0.5
+        @test mxh.a ≈ 0.9
+        @test mxh.minor_radius ≈ 0.9
+        @test mxh.elongation == 1.8
+        @test mxh.tilt == 0.0
+        @test mxh.triangularity ≈ 0.4
+        @test mxh.δ ≈ 0.4
+        @test mxh.squareness ≈ 0.1
+        @test mxh.ovality == 0.0
+        @test mxh.twist == 0.0
+
+        # property aliases write through to the underlying fields
+        mxh.triangularity = 0.3
+        @test mxh.s[1] ≈ asin(0.3)
+        mxh.squareness = 0.05
+        @test mxh.s[2] ≈ -0.05
+        mxh.ovality = 0.02
+        @test mxh.c[1] == 0.02
+        mxh.minor_radius = 1.2
+        @test mxh.ϵ ≈ 1.2 / 3.0
+
+        # MXH(R0, n_coeffs) gives an unshaped default surface
+        m0 = MXH(3.0, 2)
+        @test m0.κ == 1.0 && m0.ϵ == 0.3 && length(m0.c) == 2 && length(m0.s) == 2
+
+        # mixed-type inputs promote
+        mi = MXH(3, 0.5, 0.3, 1.8, 0, [0.0], [0.0])
+        @test mi.R0 === 3.0 && mi.c0 === 0.0
+    end
+
+    @testset "flat_coeffs round-trip and copy_MXH!" begin
+        mxh = MXH(3.0, 0.5, 0.3, 1.8, 0.1, [0.02, -0.01], [0.3, -0.05])
+        flat = flat_coeffs(mxh)
+        @test flat == [3.0, 0.5, 0.3, 1.8, 0.1, 0.02, -0.01, 0.3, -0.05]
+
+        buf = zeros(9)
+        @test flat_coeffs!(buf, mxh) == flat
+
+        back = MXH(flat)
+        @test flat_coeffs(back) == flat
+
+        dest = MXH(1.0, 2)
+        copy_MXH!(dest, mxh)
+        @test flat_coeffs(dest) == flat
+        # copy_MXH! copies values, it must not alias the vectors
+        dest.c[1] = 99.0
+        @test mxh.c[1] == 0.02
+    end
+
+    @testset "boundary evaluation" begin
+        # κ=1 and no shaping coefficients → exact circle
+        R0, Z0, ϵ = 3.0, 0.5, 0.3
+        a = R0 * ϵ
+        circ = MXH(R0, Z0, ϵ, 1.0, 0.0, zeros(2), zeros(2))
+        for θ in (0.0, π / 3, π / 2, π, 1.7π)
+            r, z = circ(θ)
+            @test r ≈ R0 + a * cos(θ)
+            @test z ≈ Z0 - a * sin(θ)
+        end
+
+        # shaped surface: analytic extremes and closed curve
+        κ = 1.8
+        mxh = MXH(R0, Z0, ϵ, κ, 0.0, zeros(3), [asin(0.4), -0.05, 0.0])
+        pr, pz = mxh(201)
+        @test pr[1] == pr[end] && pz[1] == pz[end]
+        @test maximum(pr) ≈ R0 + a rtol = 1e-8   # R(0) = R0 + a is the global max
+        @test maximum(pz) ≈ Z0 + κ * a atol = 1e-3
+        @test minimum(pz) ≈ Z0 - κ * a atol = 1e-3
+    end
+
+    @testset "fit round-trip" begin
+        truth = MXH(3.0, 0.5, 0.32, 1.8, 0.0, [0.0, 0.0, 0.0], [asin(0.45), -0.07, 0.0])
+        pr, pz = truth(400)
+        for kw in ((;), (; spline=true), (; optimize_fit=true))
+            fit = MXH(pr, pz, 3; kw...)
+            @test fit.R0 ≈ truth.R0 rtol = 1e-3
+            @test fit.Z0 ≈ truth.Z0 atol = 1e-3
+            @test fit.ϵ ≈ truth.ϵ rtol = 1e-3
+            @test fit.κ ≈ truth.κ rtol = 1e-3
+            @test fit.c ≈ truth.c atol = 5e-3
+            @test fit.s ≈ truth.s atol = 5e-3
+        end
+    end
+
+    @testset "in_surface / nearest_angle" begin
+        mxh = MXH(3.0, 0.5, 0.3, 1.8, 0.0, zeros(2), [asin(0.3), 0.0])
+        a = mxh.a
+        @test MXHmod.in_surface(mxh.R0, mxh.Z0, mxh)
+        @test MXHmod.in_surface(mxh.R0 + 0.99 * a, mxh.Z0, mxh)
+        @test !MXHmod.in_surface(mxh.R0 + 1.01 * a, mxh.Z0, mxh)
+        @test !MXHmod.in_surface(mxh.R0, mxh.Z0 + 1.01 * mxh.κ * a, mxh)
+
+        # a boundary point of a circle maps back to its own angle
+        circ = MXH(3.0, 0.0, 0.3, 1.0, 0.0, zeros(2), zeros(2))
+        θq = 0.4
+        Rq = 3.0 + circ.a * cos(θq)
+        Zq = -circ.a * sin(θq)
+        @test MXHmod.nearest_angle(Rq, Zq, circ) ≈ θq
+        # beyond the vertical extent → ±π/2
+        @test MXHmod.nearest_angle(3.0, -2 * circ.a, circ) ≈ π / 2
+        @test MXHmod.nearest_angle(3.0, +2 * circ.a, circ) ≈ -π / 2
+    end
+
+    @testset "metric derivatives vs finite differences" begin
+        mxh = MXH(3.0, 0.5, 0.3, 1.8, 0.1, [0.02, -0.01], [0.3, -0.05])
+        h = 1e-6
+        for θ in (0.3, 1.2, 2.5, 4.0, 5.9)
+            num = (MXHmod.R_MXH(θ + h, mxh) - MXHmod.R_MXH(θ - h, mxh)) / (2h)
+            @test MXHmod.dR_dθ(θ, mxh.R0, mxh.ϵ, mxh.c0, mxh.c, mxh.s) ≈ num atol = 1e-5
+            @test MXHmod.dZ_dθ(θ, mxh.R0, mxh.ϵ, mxh.κ) ≈ -mxh.κ * mxh.R0 * mxh.ϵ * cos(θ) atol = 1e-12
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- **Optim v2 support**: v2 requires an ADTypes backend for `autodiff` and an explicitly loaded ForwardDiff. Select by version, add ForwardDiff as a dependency, widen `Optim = "1, 2"`.
- **Tests + CI**: new test suite (66 tests) and CI workflow — this is what caught the breakage.
- **Known upstream issue** (not fixed here): Optim v1 + LineSearches v7.5 breaks `optimize_fit`; use LineSearches ≤ 7.4 or Optim v2. No FUSE ecosystem impact (`optimize_fit=true` is unused).
